### PR TITLE
Fixed setting decreasing numbers

### DIFF
--- a/js/flipcounter.js
+++ b/js/flipcounter.js
@@ -194,6 +194,7 @@ var flipCounter = function(d, options){
       dlen = decimalsNew.length;
     }
 
+    digitsAnimate = []; //reset to reset correctly all digit placeholder
     for (var i = 0; i < ylen; i++){
 
       if (i < dlen) {
@@ -264,8 +265,13 @@ var flipCounter = function(d, options){
 
     var alen = digitsAnimate.length;
 
+    if (this.lastTimeout) {
+        //reset timeout, so very fast setValue() calls work correctly without race conditions
+        clearTimeout(this.lastTimeout);
+        this.lastTimeout = null;
+    }
     // Need a slight delay before adding the 'animate' class or else animation won't fire on FF
-    setTimeout(function(){
+    this.lastTimeout = setTimeout(function(){
       for (var i = 0; i < alen; i++){
         if (digitsAnimate[i]){
           var a = doc.getElementById(d+'-digit-a'+i);

--- a/js/flipcounter.js
+++ b/js/flipcounter.js
@@ -28,7 +28,7 @@ var flipCounter = function(d, options){
     counter[opt] = counter.hasOwnProperty(opt) ? counter[opt] : defaults[opt];
   }
 
-  var digitsOld = [], digitsNew = [],decimalsOld = [], decimalsNew = [], digitsAnimate = [], x, y, nextCount = null;
+  var digitsOld = [], digitsNew = [],decimalsOld = [], decimalsNew = [], digitsAnimate = [], x, y, lastTimeout, nextCount = null;
 
   var div = d;
   if (typeof d === 'string'){
@@ -265,13 +265,13 @@ var flipCounter = function(d, options){
 
     var alen = digitsAnimate.length;
 
-    if (this.lastTimeout) {
+    if (lastTimeout) {
         //reset timeout, so very fast setValue() calls work correctly without race conditions
-        clearTimeout(this.lastTimeout);
-        this.lastTimeout = null;
+        clearTimeout(lastTimeout);
+        lastTimeout = null;
     }
     // Need a slight delay before adding the 'animate' class or else animation won't fire on FF
-    this.lastTimeout = setTimeout(function(){
+    lastTimeout = setTimeout(function(){
       for (var i = 0; i < alen; i++){
         if (digitsAnimate[i]){
           var a = doc.getElementById(d+'-digit-a'+i);


### PR DESCRIPTION
Following code didn't work correctly

```javascript
var counter = new flipCounter('c1', defaults);
counter.setValue(123233);
counter.setValue(23);
```

it produced something like 
<img width="700" alt="screenshot 2015-07-31 23 12 49" src="https://cloud.githubusercontent.com/assets/450980/9017843/ab99023e-37d9-11e5-8271-0b73eaf4ef33.png">

Also fixed some race conditions when calling setValue too fast.
