### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-#CSS Flip Counter
+# CSS Flip Counter
 
 [http://cnanney.com/journal/code/css-flip-counter-revisited/](http://cnanney.com/journal/code/css-flip-counter-revisited/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
